### PR TITLE
Sponsors styling fixes

### DIFF
--- a/Frontend/src/components/SponsorCard.vue
+++ b/Frontend/src/components/SponsorCard.vue
@@ -1,13 +1,10 @@
 <template>
   <div class="card mb-2">
     <div class="card-body row">
-      <div class="col-md-6 col-12 mb-2">
+      <div class="col-md-8 col-sm-6 col-12 mb-2">
         <h5 class="mt-0">{{ sponsor.name }}</h5>
         <p>{{ sponsor.tagline }}</p>
-        <a
-          :href="sponsor.website"
-          target="_blank"
-          class="btn btn-outline-primary"
+        <a :href="sponsor.website" target="_blank" class="btn btn-primary"
           >Zur Webseite</a
         >
       </div>
@@ -19,7 +16,7 @@
         {{ sponsor.contacts?.phone }}<br />
         {{ sponsor.contacts?.phone2 }}<br />
       </div>
-      <div class="col-md-4 col-12">
+      <div class="col-md-4 col-sm-6 col-12 text-end">
         <a :href="sponsor.website" target="_blank" class="square-holder">
           <img :src="baseURL + `media/` + sponsor.logo?.id" />
         </a>

--- a/Frontend/src/components/SponsorCard.vue
+++ b/Frontend/src/components/SponsorCard.vue
@@ -1,24 +1,26 @@
 <template>
-  <div class="card-header"></div>
-  <div class="card-body row justify-content-start align-items-center">
-    <!-- TODO: Cols should wrap in own row when viewport width shrinks -->
-    <div class="col-3">
-      <h5 class="card-title">{{ sponsor.name }}</h5>
-      <p class="card-text">{{ sponsor.tagline }}</p>
-      <!-- TODO: Reevaluate if it's a good decision to use a button. Steph has mentioned that he wants to get a note when a button would leads to an external website. -->
-      <a :href="sponsor.website" target="_blank" class="btn btn-primary">{{
-        linkMessage
-      }}</a>
-    </div>
-    <div class="col-3">
-      <div>{{ sponsor.contacts?.address }}</div>
-      <div>{{ sponsor.contacts?.email }}</div>
-      <div>{{ sponsor.contacts?.phone }}</div>
-      <div>{{ sponsor.contacts?.phone2 }}</div>
-    </div>
-    <div class="col-3">
-      <div class="square-holder">
-        <a :href="sponsor.website" target="_blank">
+  <div class="card mb-2">
+    <div class="card-body row">
+      <div class="col-md-6 col-12 mb-2">
+        <h5 class="mt-0">{{ sponsor.name }}</h5>
+        <p>{{ sponsor.tagline }}</p>
+        <a
+          :href="sponsor.website"
+          target="_blank"
+          class="btn btn-outline-primary"
+          >Zur Webseite</a
+        >
+      </div>
+      <!-- TODO: Braucht es das überhaupt? 
+      Die aktuellen Kontaktdaten stehen eh auf der verlinkten Webseite-->
+      <div v-if="false" class="col-md-6 col-12 mb-2">
+        {{ sponsor.contacts?.address }}<br />
+        {{ sponsor.contacts?.email }}<br />
+        {{ sponsor.contacts?.phone }}<br />
+        {{ sponsor.contacts?.phone2 }}<br />
+      </div>
+      <div class="col-md-4 col-12">
+        <a :href="sponsor.website" target="_blank" class="square-holder">
           <img :src="baseURL + `media/` + sponsor.logo?.id" />
         </a>
       </div>
@@ -34,16 +36,13 @@ defineProps({
     type: Object,
     required: true,
   },
-  linkMessage: {
-    type: String,
-    default: "Erfahre mehr",
-  },
 });
 </script>
 
 <style scoped>
 img {
-  max-height: 100px;
+  max-height: 8em;
+  max-width: 10em;
 }
 .square-holder {
   padding: 5px;
@@ -52,8 +51,7 @@ img {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 150px;
-  max-width: 100%;
+  min-height: 10em;
 }
 
 .square-holder:hover {

--- a/Frontend/src/components/resultsTables/FlightsTable.vue
+++ b/Frontend/src/components/resultsTables/FlightsTable.vue
@@ -18,7 +18,7 @@
           </thead>
           <tbody>
             <tr
-              v-for="(flight, index) in flights.slice(0, maxRows)"
+              v-for="(flight, index) in flights"
               :key="flight.id"
               :item="flight"
               :index="index"
@@ -68,7 +68,6 @@ defineProps({
     type: Array,
     required: true,
   },
-  maxRows: { type: Number, required: true },
 });
 const routeToFlight = (flightId) => {
   router.push({

--- a/Frontend/src/views/SponsorsList.vue
+++ b/Frontend/src/views/SponsorsList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <div class="container col-md-10 col-lg-8 col-12 mx-automx-auto">
     <h3>Sponsoren des Jahres {{ new Date().getFullYear() }}</h3>
     <SponsorCard
       v-for="sponsor in sponsors"

--- a/Frontend/src/views/SponsorsList.vue
+++ b/Frontend/src/views/SponsorsList.vue
@@ -1,13 +1,10 @@
 <template>
-  <div class="container-fluid">
+  <div class="container">
     <h3>Sponsoren des Jahres {{ new Date().getFullYear() }}</h3>
-  </div>
-  <div v-for="sponsor in sponsors" :key="sponsor.id" class="card">
     <SponsorCard
+      v-for="sponsor in sponsors"
+      :key="sponsor.id"
       :sponsor="sponsor"
-      :link-message="
-        linkMessages[Math.floor(Math.random() * linkMessages.length)]
-      "
     />
   </div>
 </template>
@@ -21,16 +18,6 @@ import { setWindowName } from "../helper/utils";
 const sponsors = ref([]);
 
 setWindowName("Sponsoren");
-
-const linkMessages = ref([
-  "Hit it!",
-  "Check it out",
-  "Klick mich",
-  "Show more",
-  "Erfahre mehr",
-  "Besuche uns",
-  "Visit us",
-]);
 
 try {
   const res = await ApiService.getSponsors();


### PR DESCRIPTION
Ich hab mal was an den Sponsoren geändert um das styling ein bisschen zu richten.
Du hast hier cards verwendet. Die sind eigentlich zum anzeigen von vertikal gestackten Informationen. Daher ist es sehr schwer hier elegante Umbrüche für unterschiedliche viewports zu machen.

Ich habs trotzdem mal versucht.

Bei der Pilotenliste habe ich es aber gelassen - das sollte man anders angehen, sonst ist das nicht wirklich zielführend. Man verwendet ja ein Framework wie bootstrap um schon auf allen viewports brauchbare Klassen zu haben. Wenn man die jetzt so umbastelt kann man es auch direkt lassen und selber stylen 😂

