### PR TITLE
Hotfix: List flights of inactive users

### DIFF
--- a/client/src/components/FilterPanel.vue
+++ b/client/src/components/FilterPanel.vue
@@ -581,7 +581,7 @@ const genderDescription = (gender) => {
   return "Divers";
 };
 
-const createFullName = (user) => user.firstName + " " + user.lastName;
+const createFullName = (user) => user?.firstName + " " + user?.lastName;
 
 onUnmounted(() => onClear());
 </script>

--- a/client/src/components/admin/AdminFlightUpload.vue
+++ b/client/src/components/admin/AdminFlightUpload.vue
@@ -124,7 +124,9 @@ fetchNames();
 async function fetchNames() {
   try {
     users.value = (await ApiService.getUserNames()).data;
-    userNames.value = users.value.map((u) => createFullname(u));
+    userNames.value = users.value
+      .filter((u) => u.role != "Inaktiv")
+      .map((u) => createFullname(u));
   } catch (error) {
     console.error(error);
   }

--- a/client/src/types/UserData.ts
+++ b/client/src/types/UserData.ts
@@ -3,6 +3,7 @@ export interface UserDataEssential {
   firstName: string;
   lastName: string;
   fullName: string;
+  role: string;
 }
 
 export interface CreateUserData extends Omit<UserData, "id"> {}

--- a/server/service/UserService.js
+++ b/server/service/UserService.js
@@ -105,14 +105,8 @@ const userService = {
 
   getAllNames: async () => {
     const users = await User.findAll({
-      where: {
-        // TODO: Decide what to do in frontend when this users really should be excluded from the list
-        // role: {
-        //   [Op.not]: ROLE.INACTIVE,
-        // },
-      },
       order: [["firstName", "asc"]],
-      attributes: ["id", "firstName", "lastName", "fullName"],
+      attributes: ["id", "firstName", "lastName", "fullName", "role"],
     });
 
     return users;

--- a/server/service/UserService.js
+++ b/server/service/UserService.js
@@ -106,9 +106,10 @@ const userService = {
   getAllNames: async () => {
     const users = await User.findAll({
       where: {
-        role: {
-          [Op.not]: ROLE.INACTIVE,
-        },
+        // TODO: Decide what to do in frontend when this users really should be excluded from the list
+        // role: {
+        //   [Op.not]: ROLE.INACTIVE,
+        // },
       },
       order: [["firstName", "asc"]],
       attributes: ["id", "firstName", "lastName", "fullName"],


### PR DESCRIPTION
If a users clicks on the name of a user in flight view he is redirected to the page that lists all of his flights.
If this listed user has role `inactive` the frontend crashes. This is because of the way the filter panel works. The Filter badge get's the name from the filter options endpoint which does not list inactive users.
This PR now also lists inactive users to prevent the frontend from crashing.
This is only a hot fix. The client should not crash and it should be decided how this case should be handled in general @KaiWissel 