### PR TITLE
refactored conversion of airspace altitude information

### DIFF
--- a/server/helper/AirspaceHeightConverter.ts
+++ b/server/helper/AirspaceHeightConverter.ts
@@ -1,0 +1,56 @@
+import logger from "../config/logger";
+import { XccupHttpError } from "./ErrorHandler";
+import { INTERNAL_SERVER_ERROR } from "../constants/http-status-constants";
+
+const FEET_IN_METER = 0.3048;
+
+/**
+ * Converts a vertical airspace limit (GND/MSL/AGL/FL) to MSL (in meter)
+ * @param {string} verticalLimit
+ * @param {number} elevation
+ * @returns
+ */
+export function convertVerticalLimitToMeterMSL(
+  verticalLimit: string,
+  elevation: number
+) {
+  if (verticalLimit.includes("GND")) {
+    return elevation ?? 0;
+  }
+
+  const heightValue = extractHeightValueFromText(verticalLimit);
+
+  if (verticalLimit.includes("AGL")) {
+    return convertFeetToMeter(heightValue) + elevation ?? 0;
+  }
+
+  if (verticalLimit.includes("MSL")) {
+    return convertFeetToMeter(heightValue);
+  }
+
+  /**
+   * This is actually not the correct way to convert a FL to a MSL altitude. On high pressure
+   * days the result will to low. But it's the only practical way for the moment because not
+   * every flightlog includes the pressure altitude…
+   */
+  if (verticalLimit.includes("FL")) {
+    return convertFeetToMeter(heightValue * 100);
+  }
+  logger.warn("AS: No parsable height value found: " + verticalLimit);
+}
+
+function convertFeetToMeter(feet: number) {
+  return feet * FEET_IN_METER;
+}
+
+function extractHeightValueFromText(textValue: string): number {
+  const result = textValue.replace(/[^0-9]/g, "");
+
+  if (!result) {
+    const message =
+      "Couldn't convert airspace height information of " + textValue;
+    throw new XccupHttpError(INTERNAL_SERVER_ERROR, message, message);
+  }
+
+  return +result;
+}

--- a/server/test/AirspaceHeightConverter.test.ts
+++ b/server/test/AirspaceHeightConverter.test.ts
@@ -64,5 +64,5 @@ test.each([
 test("No number at all should throw an error", () => {
   expect(() => {
     convertVerticalLimitToMeterMSL("foobar MSL", 0);
-  }).toThrow("Couldn't convert to a height value in meter");
+  }).toThrow("Couldn't convert airspace height information of");
 });

--- a/server/test/AirspaceHeightConverter.test.ts
+++ b/server/test/AirspaceHeightConverter.test.ts
@@ -38,8 +38,12 @@ test.each([
 test.each([
   ["3500F AGL", 100, 1166.8],
   ["3500FT AGL", 200, 1266.8],
+  ["3500 F AGL", 100, 1166.8],
+  ["3500 FT AGL", 200, 1266.8],
   ["3500f AGL", 300, 1366.8],
   ["3500ft AGL", 400, 1466.8],
+  ["3500 f AGL", 300, 1366.8],
+  ["3500 ft AGL", 400, 1466.8],
 ])(
   "Convert AGL value %s with elevation %i to %i",
   (value, elevation, expected) => {

--- a/server/test/AirspaceHeightConverter.test.ts
+++ b/server/test/AirspaceHeightConverter.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment node
+ */
+import { convertVerticalLimitToMeterMSL } from "../helper/AirspaceHeightConverter";
+
+test.each([
+  ["3500F MSL", 1066.8],
+  ["3500FT MSL", 1066.8],
+  ["3500F AMSL", 1066.8],
+  ["3500FT AMSL", 1066.8],
+  ["3500f MSL", 1066.8],
+  ["3500ft MSL", 1066.8],
+  ["3500ft AMSL", 1066.8],
+  ["3500ft AMSL", 1066.8],
+])("Convert MSL value %s to %i", (value, expected) => {
+  const converted = convertVerticalLimitToMeterMSL(value, 0);
+  expect(converted).toBe(expected);
+});
+
+test.each([
+  ["3500F AGL", 1066.8],
+  ["3500FT AGL", 1066.8],
+  ["3500f AGL", 1066.8],
+  ["3500ft AGL", 1066.8],
+])("Convert AGL value %s to %i", (value, expected) => {
+  const converted = convertVerticalLimitToMeterMSL(value, 0);
+  expect(converted).toBe(expected);
+});
+
+test.each([
+  ["FL100", 3048],
+  ["FL 80", 2438.4],
+])("Convert FL value %s to %i", (value, expected) => {
+  const converted = convertVerticalLimitToMeterMSL(value, 0);
+  expect(converted).toBe(expected);
+});
+
+test.each([
+  ["3500F AGL", 100, 1166.8],
+  ["3500FT AGL", 200, 1266.8],
+  ["3500f AGL", 300, 1366.8],
+  ["3500ft AGL", 400, 1466.8],
+])(
+  "Convert AGL value %s with elevation %i to %i",
+  (value, elevation, expected) => {
+    const converted = convertVerticalLimitToMeterMSL(value, elevation);
+    expect(converted).toBe(expected);
+  }
+);
+
+test.each([
+  ["GND", 100, 100],
+  ["GND", 0, 0],
+  ["1500F GND", 0, 0],
+  ["1500F GND", 42, 42],
+])(
+  "Convert GND value %s with elevation %i to %i",
+  (value, elevation, expected) => {
+    const converted = convertVerticalLimitToMeterMSL(value, elevation);
+    expect(converted).toBe(expected);
+  }
+);
+
+test("No number at all should throw an error", () => {
+  expect(() => {
+    convertVerticalLimitToMeterMSL("foobar MSL", 0);
+  }).toThrow("Couldn't convert to a height value in meter");
+});


### PR DESCRIPTION
Dieser PR bezieht sich auf die Mail von Torsten.

Ich habe vor ein paar Tagen die Airspaces aktualisiert. Leider haben sich dabei neue Formate für die Höhenangaben reingeschmuggelt. Die dann nun auf Null gelaufen sind.

Habe den ganzen Code an der Stelle refactored und Unit-Test für die Umrechnung ergänzt.