### PR TITLE
fix testcase flights filter

### DIFF
--- a/client/cypress/e2e/pages/flightsall.cy.js
+++ b/client/cypress/e2e/pages/flightsall.cy.js
@@ -80,7 +80,7 @@ describe("check flights all page", () => {
     );
   });
 
-  it("test filter", () => {
+  it.only("test filter", () => {
     cy.intercept("GET", "/api/flights*").as("get-flights");
 
     const expectedClub = "Die Moselfalken";
@@ -143,7 +143,9 @@ describe("check flights all page", () => {
       .first()
       .should("include.text", "Die Moselfalken")
       .and("include.text", "Die Elstern")
-      .and("include.text", "Sky Apollo");
+      .and("include.text", "Sky Apollo")
+      .and("include.text", "km")
+      .and("include.text", "P");
   });
 
   it("test sort on points ascending", () => {

--- a/client/cypress/e2e/pages/flightsall.cy.js
+++ b/client/cypress/e2e/pages/flightsall.cy.js
@@ -80,7 +80,7 @@ describe("check flights all page", () => {
     );
   });
 
-  it("test filter", () => {
+  it.only("test filter", () => {
     cy.intercept("GET", "/api/flights*").as("get-flights");
 
     const expectedClub = "Die Moselfalken";
@@ -141,13 +141,9 @@ describe("check flights all page", () => {
     cy.get("table")
       .find("tr")
       .first()
-      .should("include.text", "Frank Jacobs")
-      .and("include.text", "Die Moselfalken")
+      .should("include.text", "Die Moselfalken")
       .and("include.text", "Die Elstern")
-      .and("include.text", "Graach")
-      .and("include.text", "Sky Apollo")
-      .and("include.text", "11 km")
-      .and("include.text", "66 P");
+      .and("include.text", "Sky Apollo");
   });
 
   it("test sort on points ascending", () => {

--- a/client/cypress/e2e/pages/flightsall.cy.js
+++ b/client/cypress/e2e/pages/flightsall.cy.js
@@ -80,7 +80,7 @@ describe("check flights all page", () => {
     );
   });
 
-  it.only("test filter", () => {
+  it("test filter", () => {
     cy.intercept("GET", "/api/flights*").as("get-flights");
 
     const expectedClub = "Die Moselfalken";


### PR DESCRIPTION
We set always 5 flights on today and 5 flights on yesterday. Flights within the table are sorted in chronological order. This leads to an error through out the year, when one flight within this filter rises from bottom to top in the table. Therefore we don't assert on flight specifics anymore but on common elements in regards to the set filters.